### PR TITLE
Fixed -  [BUG] template_vars not being stored correctly in the SQL Da…

### DIFF
--- a/promptmage/storage/sqlite_backend.py
+++ b/promptmage/storage/sqlite_backend.py
@@ -148,7 +148,7 @@ class SQLitePromptBackend(StorageBackend):
             ).scalar_one_or_none()
             if prompt is None:
                 raise PromptNotFoundException(f"Prompt with ID {prompt_id} not found.")
-            return prompt
+            return Prompt(**prompt.to_dict())
         finally:
             session.close()
 


### PR DESCRIPTION
Changed the below code

Before
```python
    def get_prompt_by_id(self, prompt_id: str) -> Prompt:
        session = self.Session()
        try:
            prompt = session.execute(
                select(PromptModel).where(PromptModel.id == prompt_id)
            ).scalar_one_or_none()
            if prompt is None:
                raise PromptNotFoundException(f"Prompt with ID {prompt_id} not found.")
            return prompt
        finally:
            session.close()
```

After
```python
    def get_prompt_by_id(self, prompt_id: str) -> Prompt:
        session = self.Session()
        try:
            prompt = session.execute(
                select(PromptModel).where(PromptModel.id == prompt_id)
            ).scalar_one_or_none()
            if prompt is None:
                raise PromptNotFoundException(f"Prompt with ID {prompt_id} not found.")
            return Prompt(**prompt.to_dict())
        finally:
            session.close()
```

Now the template_vars is correctly stored in the SQL Database